### PR TITLE
Initialization of variable in check_rhev3.pl

### DIFF
--- a/plugin-dir/check_rhev3.pl
+++ b/plugin-dir/check_rhev3.pl
@@ -1473,6 +1473,7 @@ sub eval_status{
   # all possible stati for datacenters, hosts and vms
   my %comp_state;
   my $tmp_state = "ok";
+  $comp_state{ 'up' } = 0;
   # all possible values for dcs/hosts/vms (needed for performance data)
   if ($component eq "Vms"){
     $comp_state{ 'powering_up' } = 0;


### PR DESCRIPTION
Bugfix of Syntaxerror for the attached call.
If only 1 Datacenter exists and the datacenter is not up there is no initialization of the variable 'up'

/githubcheck_rhev3/plugin-dir/check_rhev3.pl -H "MY-IP" -a "MY-LOGIN" -D "MY-DATACENTER" -s status
Use of uninitialized value $comp_state{"up"} in concatenation (.) or string at /github/check_rhev3/plugin-dir/check_rhev3.pl line 1548.
Use of uninitialized value in numeric eq (==) at /github/check_rhev3/plugin-dir/check_rhev3.pl line 1572.
Use of uninitialized value in numeric gt (>) at /github/check_rhev3/plugin-dir/check_rhev3.pl line 1572.
Use of uninitialized value in numeric gt (>) at /github/check_rhev3/plugin-dir/check_rhev3.pl line 1574.
Use of uninitialized value $comp_state{"up"} in concatenation (.) or string at /github/check_rhev3/plugin-dir/check_rhev3.pl line 1577.
RHEV CRITICAL: Datacenters critical - /1 Datacenters with state UP |up=;1;1;0; problematic=1;;;0; uninitialized=0;;;0; not_operational=0;;;0; maintenance=0;;;0; contend=0;;;0; 

Same call after the fix:
RHEV CRITICAL: Datacenters critical - 0/1 Datacenters with state UP |up=0;1;1;0; problematic=1;;;0; uninitialized=0;;;0; not_operational=0;;;0; maintenance=0;;;0; contend=0;;;0;
