### PR TITLE
align behaviour for check_statistics cpu to memory

### DIFF
--- a/plugin-dir/check_rhev3.pl
+++ b/plugin-dir/check_rhev3.pl
@@ -1177,7 +1177,7 @@ sub get_stats {
         my $cpu_user   = $result{statistic}{"cpu.current.user"}{values}{value}{datum};
            $cpu_usage  = 100 - $cpu_idle;
            # if host is in maintenance mode or down, REST-API reports 0 values
-           $cpu_usage = -1 if $cpu_idle == 0 && $cpu_system == 0 && $cpu_user == 0;
+           $cpu_usage = 0 if $cpu_idle == 0 && $cpu_system == 0 && $cpu_user == 0;
         $rethash{$key}{stats}{"cpu.current.idle"} = $cpu_idle;
         $rethash{$key}{stats}{"cpu.current.system"} = $cpu_system;
         $rethash{$key}{stats}{"cpu.current.user"} = $cpu_user;


### PR DESCRIPTION
check_statistics memory returns OK and 0% for non-active hosts.
check_statistics cpu returns UNKNOWN and ?% for non-active hosts.

This changes the behaviour of check_statistics cpu to that of check_statistics memory, which is the way we prefer. Otherwise we would have to acknowledge or set downtime on multiple services instead of just the status service.