### PR TITLE
cluster hosts - alert on impossible thresholds

### DIFF
--- a/plugin-dir/check_rhev3.pl
+++ b/plugin-dir/check_rhev3.pl
@@ -1612,7 +1612,11 @@ sub eval_status{
     $info .= "]";
   }
   
-  if ( ( ($comp_state{ 'up' } == $size) && ($size != 0) && $tmp_state eq "ok" ) || ( ($comp_state{ 'up' } > $o_warn) && ($comp_state{ 'up' } > $o_crit) && $tmp_state eq "ok" ) ){
+  if ($o_crit > $comp_state{ 'up' } && $tmp_state eq "ok"){
+    exit_plugin('unknown',$component,"critical threshold is larger than numbers of cluster nodes - $comp_state{ 'up' }/$size " . ucfirst($component) . " with state $state $info< critical threshold $o_crit" . $perf);
+  }elsif ($o_warn > $comp_state{ 'up' } && $tmp_state eq "ok"){
+    exit_plugin('unknown',$component,"warning threshold is larger than numbers of cluster nodes - $comp_state{ 'up' }/$size " . ucfirst($component) . " with state $state $info< warning threshold $o_warn" . $perf);
+  }elsif ( ( ($comp_state{ 'up' } == $size) && ($size != 0) && $tmp_state eq "ok" ) || ( ($comp_state{ 'up' } > $o_warn) && ($comp_state{ 'up' } > $o_crit) && $tmp_state eq "ok" ) ){
     exit_plugin('ok',$component,"$comp_state{ 'up' }/$size " . ucfirst($component) . " with state $state $info" . $perf);
   }elsif ($tmp_state ne "critical" && $comp_state{ 'up' } > $o_crit){
     exit_plugin('warning',$component,"$comp_state{ 'up' }/$size " . ucfirst($component) . " with state $state $info" . $perf);


### PR DESCRIPTION
At the moment if I check against a cluster consisting of n cluster nodes a threshold of x which is larger than n results in a OK status.

```
$ ./check_rhev3.pl [...] -l hosts --critical 18
RHEV OK: Hosts ok - 16/16 Hosts with state UP |Hosts_up=16;16;18;0;
```

This checks if one of the thresholds is larger than the numbers of cluster nodes and returns UNKNOWN with an descriptive status text:
```
$ ./check_rhev3.pl [...] -l hosts --critical 18
RHEV UNKNOWN: Hosts unknown - critical threshold is larger than numbers of cluster nodes - 16/16 Hosts with state UP < critical threshold 18|Hosts_up=16;16;18;0;
```