### PR TITLE
Explicitly use version 3 of the API

### DIFF
--- a/plugin-dir/check_rhev3.pl
+++ b/plugin-dir/check_rhev3.pl
@@ -1682,6 +1682,9 @@ sub rhev_connect{
 
   my $rr = HTTP::Request->new(GET => $rhevm_url);
 
+  # explicitly use version 3 of the API
+  $rr->header('Version' => '3');
+
   # cookie authentication or basic auth
   my $cf = `echo "$o_rhevm_host-$rhevm_user" | base64 -w0`;
   chomp $cf;


### PR DESCRIPTION
Veersion 4 of the oVirt engine will support two versions of the API:
version 3, which will be backwards compatible with older versions of the
engine and version 4, which won't be compatible. The default used by the
server will be version 4, but clients can explicitly request a version
of the API using the "Version" header or the "/v3" URL prefix. The
header is the preferred mechanism because it is just ignored by older
versions of the server. This patch modifies the the "check_rhev3.pl"
script so that it always send the header explicitly, so that it will
work with version 4 of the engine.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>