### PR TITLE
Fix network error detection

### DIFF
--- a/plugin-dir/check_rhev3.pl
+++ b/plugin-dir/check_rhev3.pl
@@ -1464,14 +1464,15 @@ sub check_nic_errors{
       print "Interface errors in file $cookie/$host/$nic not a number: $errors\n";
       exit $ERRORS{$status{'unknown'}};
     }
+
     $return = $error - $errors;
     # set counter to 0 if value is negative
     # this can happen if counter is reseted on host (e.g. reboot)
     $return = 0 if $return < 0;
-    write_errors_file($cookie . "/" . $host . "/" . $nic, $return);
+    write_errors_file($cookie . "/" . $host . "/" . $nic, $error);
   }else{
     $return = $error;
-    write_errors_file($cookie . "/" . $host . "/" . $nic, $return);
+    write_errors_file($cookie . "/" . $host . "/" . $nic, $error);
   }
   
   return $return;
@@ -1805,4 +1806,3 @@ sub rest_api_connect{
 }
 
 exit $ERRORS{$status{'unknown'}};
-


### PR DESCRIPTION
# check_rhev3.pl -o -A "/ovirt-engine/api" --ca-file=/etc/nrpe.d/manager.cert -f /etc/nrpe.d/manager.auth -H manager_host -p 443 -M VM_name -l network -s errors

We noticed that this check flaps between OK and CRITICAL state whenever a VM has NIC errors.

We changed this so that the check returns error / CRITICAL state only if the number of NIC errors increases - otherwise, it returns OK.